### PR TITLE
17 refactor change errorcode to interface for extensibility across services

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'com.fhsh'
-version = '0.1.0-SNAPSHOT'
+version = '0.1.1-SNAPSHOT'
 
 java {
 	toolchain {
@@ -63,7 +63,7 @@ publishing {
 			from components.java
 			groupId = 'com.fhsh.daitda'
 			artifactId = 'common'
-			version = '0.1.0-SNAPSHOT'
+			version = '0.1.1-SNAPSHOT'
 		}
 	}
 	repositories {

--- a/src/main/java/com/fhsh/daitda/exception/CommonErrorCode.java
+++ b/src/main/java/com/fhsh/daitda/exception/CommonErrorCode.java
@@ -1,0 +1,26 @@
+package com.fhsh.daitda.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum CommonErrorCode {
+    // 인증/인가(Global목적 - 추후 불필요하면 삭제)
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다"),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "권한이 없습니다"),
+
+    // 입력 오류
+    INVALID_INPUT(HttpStatus.BAD_REQUEST, "잘못된 입력입니다"),
+    INVALID_PATH(HttpStatus.NOT_FOUND, "잘못된 경로입니다"),
+
+    // 서버 오류
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류가 발생했습니다"),
+
+    // 충돌
+    CONFLICT(HttpStatus.CONFLICT, "이미 존재하는 데이터입니다");
+
+    private final HttpStatus status;
+    private final String description;
+}

--- a/src/main/java/com/fhsh/daitda/exception/CommonErrorCode.java
+++ b/src/main/java/com/fhsh/daitda/exception/CommonErrorCode.java
@@ -6,7 +6,7 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 @AllArgsConstructor
-public enum CommonErrorCode {
+public enum CommonErrorCode implements ErrorCode{
     // 인증/인가(Global목적 - 추후 불필요하면 삭제)
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다"),
     FORBIDDEN(HttpStatus.FORBIDDEN, "권한이 없습니다"),

--- a/src/main/java/com/fhsh/daitda/exception/ErrorCode.java
+++ b/src/main/java/com/fhsh/daitda/exception/ErrorCode.java
@@ -1,26 +1,9 @@
 package com.fhsh.daitda.exception;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
-@Getter
-@AllArgsConstructor
-public enum ErrorCode {
-    // 인증/인가(Global목적 - 추후 불필요하면 삭제)
-    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다"),
-    FORBIDDEN(HttpStatus.FORBIDDEN, "권한이 없습니다"),
-
-    // 입력 오류
-    INVALID_INPUT(HttpStatus.BAD_REQUEST, "잘못된 입력입니다"),
-    INVALID_PATH(HttpStatus.NOT_FOUND, "잘못된 경로입니다"),
-
-    // 서버 오류
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류가 발생했습니다"),
-
-    // 충돌
-    CONFLICT(HttpStatus.CONFLICT, "이미 존재하는 데이터입니다");
-
-    private final HttpStatus status;
-    private final String description;
+public interface ErrorCode {
+    String name();
+    HttpStatus getStatus();
+    String getDescription();
 }


### PR DESCRIPTION
## 🌱 설명
common 모듈의 `ErrorCode`를 enum에서 interface로 변경하여
각 서비스에서 도메인별 ErrorCode를 확장할 수 있도록 수정했습니다.
버전이 `0.1.0-SNAPSHOT` → `0.1.1-SNAPSHOT` 으로 업데이트되었습니다.

## 📌 관련 이슈
- close #17

## ✅ 주요 변경 사항
- `ErrorCode` enum → interface로 변경 (`name()`, `getStatus()`, `getDescription()` 메서드 정의)
- 기존 공통 에러코드를 `CommonErrorCode` enum으로 분리하여 `ErrorCode` 인터페이스 구현
- `BusinessException`, `GlobalExceptionHandler`가 `ErrorCode` 인터페이스를 받도록 수정
- common 모듈 버전 `0.1.0-SNAPSHOT` → `0.1.1-SNAPSHOT` 업데이트

## 📝 체크리스트
- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [ ] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [x] 제가 작성한 코드를 스스로 리뷰했나요?
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명
- common 모듈 변경으로 인해 **팀원들은 반드시 버전 업데이트 후 Gradle 새로고침** 필요합니다.
- 각 서비스에서 아래와 같이 도메인별 ErrorCode를 작성하시면 됩니다.

:wrench: 적용 방법
1. build.gradle 버전 수정(0.1.0-SNAPSHOT -> 0.1.1-SNAPSHOT)
implementation 'com.fhsh.daitda:common:0.1.1-SNAPSHOT'

2. Gradle 새로고침
./gradlew dependencies --refresh-dependencies
또는 IntelliJ Gradle 패널 새로고침 버튼 클릭

3. 각 서비스에서 도메인별 ErrorCode 작성
첨부된 파일을 담당 서비스의  com/fhsh/daitda/domain 에 'exception' 패키지를 생성하고, 하위에 Slack에 공유된 첨부파일(DeliveryErrorCode.java)을 첨부해 주십시오.

3-1. 첨부된 클래스를 각자 도메인에 알맞게 수정하십시오.
DeliveryErrorCode -> *ErrorCode

4. 각자 비지니스 상황에 맞게 에러코드 사용

고맙습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 프로젝트 버전을 0.1.0-SNAPSHOT에서 0.1.1-SNAPSHOT으로 업데이트했습니다.

* **Refactor**
  * 에러 처리 시스템의 구조를 개선했습니다.
  * 표준화된 에러 코드 및 상태 정보를 정의하여 일관된 에러 응답을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->