### PR TITLE
Fix: CommonResponse 역직렬화 기능 제공

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,8 +4,8 @@ plugins {
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
-group = 'com.fhsh'
-version = '0.1.1-SNAPSHOT'
+group = 'com.fhsh.daitda'
+version = '0.1.2-SNAPSHOT'
 
 java {
 	toolchain {
@@ -61,9 +61,7 @@ publishing {
 	publications {
 		gpr(MavenPublication) {
 			from components.java
-			groupId = 'com.fhsh.daitda'
 			artifactId = 'common'
-			version = '0.1.1-SNAPSHOT'
 		}
 	}
 	repositories {
@@ -71,8 +69,8 @@ publishing {
 			name = "GitHubPackages"
 			url = uri("https://maven.pkg.github.com/FiveHandSixHand/common-service")
 			credentials {
-				username = env["GITHUB_USERNAME"]
-				password = env["GITHUB_TOKEN"]
+				username = System.getenv("GITHUB_USERNAME")
+				password = System.getenv("GITHUB_TOKEN")
 			}
 		}
 	}

--- a/src/main/java/com/fhsh/daitda/response/CommonResponse.java
+++ b/src/main/java/com/fhsh/daitda/response/CommonResponse.java
@@ -2,8 +2,12 @@ package com.fhsh.daitda.response;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
+@Setter
+@NoArgsConstructor
 @AllArgsConstructor
 public class CommonResponse<T> {
     private int status;


### PR DESCRIPTION
## 🌱 설명

CommonResponse에서 역직렬화 기능을 제공하도록 변경하여 Feign의 응답으로 사용하도록 함

## 📌 관련 이슈

- close #19 

## ✅ 주요 변경 사항

- 빈 객체 생성 및 필드 값 주입이 가능하도록 @NoArgsConstructor, @Setter 어노테이션 추가
- 빌드와 배포의 groupId, version을 각각 관리하던 부분을 하나로 병합

## 📝 체크리스트

> PR 올리기 전에 아래 항목을 확인해주세요.

- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [ ] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [x] 제가 작성한 코드를 스스로 리뷰했나요?
- [ ] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명

> 리뷰어가 참고해야 할 내용이 있다면 자유롭게 작성해주세요. (선택)

CommonResponse를 사용하여 Feign 응답을 받고, getData()로 응답 객체 내용을 추출할 수 있습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 프로젝트 버전을 0.1.2-SNAPSHOT으로 업데이트했습니다.
  * 발행 구성을 최적화했습니다.
  * GitHub Packages 발행 자격증명 처리 방식을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->