### PR TITLE
Fix: User 관련 감사 필드 선언 UUID로 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'com.fhsh.daitda'
-version = '0.1.3-SNAPSHOT'
+version = '0.1.4-SNAPSHOT'
 
 java {
 	toolchain {

--- a/src/main/java/com/fhsh/daitda/domain/BaseUserEntity.java
+++ b/src/main/java/com/fhsh/daitda/domain/BaseUserEntity.java
@@ -26,7 +26,7 @@ public abstract class BaseUserEntity extends BaseEntity {
     protected UUID deletedBy;
 
     // Soft Delete 구현
-    protected void delete(UUID deletedBy) {
+    public void delete(UUID deletedBy) {
         // 중복 삭제로 인해 삭제 관련 필드가 업데이트되는 상황을 방지
         if (isDeleted()) {
             return;

--- a/src/main/java/com/fhsh/daitda/domain/BaseUserEntity.java
+++ b/src/main/java/com/fhsh/daitda/domain/BaseUserEntity.java
@@ -7,40 +7,33 @@ import lombok.Getter;
 import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.LastModifiedBy;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-import org.springframework.util.StringUtils;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Getter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 public abstract class BaseUserEntity extends BaseEntity {
 
-    private static final int AUDITOR_MAX_LENGTH = 45;
-
     @CreatedBy
-    @Column(length = AUDITOR_MAX_LENGTH, updatable = false)
-    protected String createdBy;
+    @Column(updatable = false)
+    protected UUID createdBy;
 
     @LastModifiedBy
-    @Column(length = AUDITOR_MAX_LENGTH)
-    protected String updatedBy;
+    protected UUID updatedBy;
 
-    @Column(length = AUDITOR_MAX_LENGTH)
-    protected String deletedBy;
+    protected UUID deletedBy;
 
     // Soft Delete 구현
-    protected void delete(String deletedBy) {
+    protected void delete(UUID deletedBy) {
         // 중복 삭제로 인해 삭제 관련 필드가 업데이트되는 상황을 방지
         if (isDeleted()) {
             return;
         }
-
-        validateAuditorLength(deletedBy);
-
-        // 삭제자가 없으면 SYSTEM 삭제로 간주
-        this.updatedBy = StringUtils.hasText(deletedBy) ? deletedBy : "SYSTEM";
-        this.deletedBy = StringUtils.hasText(deletedBy) ? deletedBy : "SYSTEM";
+        
+        this.updatedBy = deletedBy;
+        this.deletedBy = deletedBy;
 
         this.updatedAt = LocalDateTime.now();
         this.deletedAt = LocalDateTime.now();
@@ -50,23 +43,16 @@ public abstract class BaseUserEntity extends BaseEntity {
         return this.deletedAt != null;
     }
 
-    public void restore(String restoredBy) {
+    // 삭제 복구
+    public void restore(UUID restoredBy) {
         if (!isDeleted()) {
             return;
         }
 
-        validateAuditorLength(restoredBy);
-
-        this.updatedBy = StringUtils.hasText(restoredBy) ? restoredBy : "SYSTEM";
+        this.updatedBy = restoredBy;
         this.deletedBy = null;
 
         this.updatedAt = LocalDateTime.now();
         this.deletedAt = null;
-    }
-
-    private void validateAuditorLength(String auditor) {
-        if (auditor != null && auditor.length() > AUDITOR_MAX_LENGTH) {
-            throw new IllegalArgumentException("auditor 정보는 %d자를 초과할 수 없습니다.".formatted(AUDITOR_MAX_LENGTH));
-        }
     }
 }


### PR DESCRIPTION
## 🌱 설명

감사 필드의 생성자, 수정자, 삭제자를 UUID로 변경

## 📌 관련 이슈

- close #24 

## ✅ 주요 변경 사항

- User 관련 감사 필드(createdBy, updatedBy, deletedBy)가 명세서와 달리 String으로 선언된 오류 수정
- 0.1.4-SNAPSHOT 버전으로 수정하여 배포

## 📝 체크리스트

> PR 올리기 전에 아래 항목을 확인해주세요.

- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [ ] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [x] 제가 작성한 코드를 스스로 리뷰했나요?
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명

> 리뷰어가 참고해야 할 내용이 있다면 자유롭게 작성해주세요. (선택)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 프로젝트 버전이 0.1.4-SNAPSHOT으로 업데이트되었습니다.

* **Bug Fixes**
  * 감사(audit) 관련 식별자 유형이 String에서 UUID로 변경되었습니다.
  * 소프트 삭제/복원 흐름이 UUID를 직접 사용하도록 수정되었고, 삭제 동작의 접근성이 공개로 변경되었습니다.
  * 감사자 길이 검증 및 "SYSTEM" 대체 로직이 제거되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->